### PR TITLE
Bump versions of required modules

### DIFF
--- a/Stucco/Stucco.psd1
+++ b/Stucco/Stucco.psd1
@@ -8,7 +8,7 @@
     Description       = 'An opinionated Plaster template for high-quality PowerShell modules'
     PowerShellVersion = '3.0'
     RequiredModules   = @(
-        @{ModuleName = 'BuildHelpers';    ModuleVersion = '2.0.8'}
+        @{ModuleName = 'BuildHelpers';    ModuleVersion = '2.0.9'}
         @{ModuleName = 'Plaster';         ModuleVersion = '1.1.3'}
         @{ModuleName = 'psake';           ModuleVersion = '4.8.0'}
         @{ModuleName = 'PowerShellBuild'; ModuleVersion = '0.3.1'}

--- a/Stucco/Stucco.psd1
+++ b/Stucco/Stucco.psd1
@@ -11,7 +11,7 @@
         @{ModuleName = 'BuildHelpers';    ModuleVersion = '2.0.8'}
         @{ModuleName = 'Plaster';         ModuleVersion = '1.1.3'}
         @{ModuleName = 'psake';           ModuleVersion = '4.8.0'}
-        @{ModuleName = 'PowerShellBuild'; ModuleVersion = '0.3.0'}
+        @{ModuleName = 'PowerShellBuild'; ModuleVersion = '0.3.1'}
     )
     FunctionsToExport = @()
     CmdletsToExport   = @()

--- a/Stucco/template/psakeFile.ps1
+++ b/Stucco/template/psakeFile.ps1
@@ -7,4 +7,4 @@ properties {
 
 task default -depends Test
 
-task Test -FromModule PowerShellBuild -Version '0.3.0'
+task Test -FromModule PowerShellBuild -Version '0.3.1'

--- a/Stucco/template/requirements.psd1
+++ b/Stucco/template/requirements.psd1
@@ -12,7 +12,7 @@
         Version = '4.8.0'
     }
     'BuildHelpers' = @{
-        Version = '2.0.8'
+        Version = '2.0.9'
     }
     'PowerShellBuild' = @{
         Version = '0.3.1'

--- a/Stucco/template/requirements.psd1
+++ b/Stucco/template/requirements.psd1
@@ -15,6 +15,6 @@
         Version = '2.0.8'
     }
     'PowerShellBuild' = @{
-        Version = '0.3.0'
+        Version = '0.3.1'
     }
 }

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -1,5 +1,5 @@
 
 task default -depends test
 
-task Test -FromModule PowerShellBuild -Version 0.3.0
+task Test -FromModule PowerShellBuild -Version 0.3.1
 

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -6,7 +6,7 @@
         Version = '4.8.0'
     }
     'BuildHelpers' = @{
-        Version = '2.0.8'
+        Version = '2.0.9'
     }
     'Plaster' = @{
         Version = '1.1.3'

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -6,15 +6,15 @@
         Version = '4.8.0'
     }
     'BuildHelpers' = @{
-        Version = '2.0.0'
+        Version = '2.0.8'
     }
     'Plaster' = @{
         Version = '1.1.3'
     }
     'PowerShellBuild' = @{
-        Version = '0.3.0'
+        Version = '0.3.1'
     }
     'PSScriptAnalyzer' = @{
-        Version = '1.18.0'
+        Version = '1.18.1'
     }
 }


### PR DESCRIPTION
psake threw an error about `PowerShellBuild` not being installed, turned out Stucco had installed `0.3.1` while `psakeFile.ps1` expected `0.3.0`. Figured I'd bump `BuildHelpers` and `PSScriptAnalyzer` to their most recent versions as well.