### PR TITLE
Omit Workflow CommandType for PowerShell Core

### DIFF
--- a/Stucco/template/psakeFile.ps1
+++ b/Stucco/template/psakeFile.ps1
@@ -3,6 +3,7 @@ properties {
     # This modifies the default behavior from the "Build" task
     # in the PowerShellBuild shared psake task module
     $PSBPreference.Build.CompileModule = $false
+    $PSBPreference.Help.DefaultLocale = 'en-US'
 }
 
 task default -depends Test

--- a/Stucco/template/tests/Help.tests.ps1
+++ b/Stucco/template/tests/Help.tests.ps1
@@ -10,7 +10,17 @@ $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVers
 # Remove all versions of the module from the session. Pester can't handle multiple versions.
 #Get-Module $env:BHProjectName | Remove-Module -Force
 Import-Module -Name (Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1") -Verbose:$false -ErrorAction Stop
-$commands = Get-Command -Module (Get-Module $env:BHProjectName) -CommandType Cmdlet, Function, Workflow  # Not alias
+
+$params = @{
+    Module = (Get-Module $env:BHProjectName)
+    CommandType = [System.Management.Automation.CommandTypes[]]'Cmdlet, Function' # Not alias
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    $params.CommandType[0] += 'Workflow'
+}
+
+$commands = Get-Command @params
 
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Not sure if this is intended for use with PowerShell Core but seems to work fine - I found I had to leave out the Workflow command type to make the template Pester test 'Help.tests.ps1' pass.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
