### PR TITLE
Update tests to support Pester 5

### DIFF
--- a/Stucco/template/tests/Help.tests.ps1
+++ b/Stucco/template/tests/Help.tests.ps1
@@ -1,118 +1,156 @@
+BeforeDiscovery {
 
-# Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
+    # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
 
-$outputDir       = Join-Path -Path $ENV:BHProjectPath -ChildPath 'Output'
-$outputModDir    = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
-$manifest        = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
-$outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputDir = Join-Path -Path $ENV:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
 
-# Get module commands
-# Remove all versions of the module from the session. Pester can't handle multiple versions.
-#Get-Module $env:BHProjectName | Remove-Module -Force
-Import-Module -Name (Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1") -Verbose:$false -ErrorAction Stop
+    # Get module commands
+    # Remove all versions of the module from the session. Pester can't handle multiple versions.
+    #Get-Module $env:BHProjectName | Remove-Module -Force
+    Import-Module -Name (Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1") -Verbose:$false -ErrorAction Stop
 
-$params = @{
-    Module = (Get-Module $env:BHProjectName)
-    CommandType = [System.Management.Automation.CommandTypes[]]'Cmdlet, Function' # Not alias
+    $params = @{
+        Module = (Get-Module $env:BHProjectName)
+        CommandType = [System.Management.Automation.CommandTypes[]]'Cmdlet, Function' # Not alias
+    }
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.CommandType[0] += 'Workflow'
+    }
+
+    $commands = Get-Command @params
+
+    ## When testing help, remember that help is cached at the beginning of each session.
+    ## To test, restart session.
+
 }
+Describe "Test help for <_.Name>" -ForEach $commands {
 
-if ($PSVersionTable.PSVersion.Major -lt 6) {
-    $params.CommandType[0] += 'Workflow'
-}
+    BeforeDiscovery {
 
-$commands = Get-Command @params
+        $commandName = $_.Name
 
-## When testing help, remember that help is cached at the beginning of each session.
-## To test, restart session.
+        # Context: Parameter help
+        $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer',
+        'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'
 
-foreach ($command in $commands) {
-    $commandName = $command.Name
+        $parameters = $_.ParameterSets.Parameters |
+        Sort-Object -Property Name -Unique |
+        Where-Object { $_.Name -notin $common }
+        $parameterNames = $parameters.Name
 
-    # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
-    $help = Get-Help $commandName -ErrorAction SilentlyContinue
+        # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+        $help = Get-Help $commandName -ErrorAction SilentlyContinue
 
-    Describe "Test help for $commandName" {
+        # Context: Help parameter help
+        ## Without the filter, WhatIf and Confirm parameters are still flagged in "finds help parameter in code" test
+        $helpParameters = $help.Parameters.Parameter |
+        Where-Object { $_.Name -notin $common } |
+        Sort-Object -Property Name -Unique
+        $helpParameterNames = $helpParameters.Name
 
-        # If help is not found, synopsis in auto-generated help is the syntax diagram
-        It 'should not be auto-generated' {
-            $help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
+        # Context: Help links
+        # Changed $link to $link*s* (original line: $link = $help.relatedLinks.navigationLink.uri)
+        $links = $help.relatedLinks.navigationLink.uri
+
+    }
+
+    BeforeAll {
+
+        # These variables are used in both Discovery and Test phases, so we need to duplicate them here in BeforeAll
+        $commandName = $_.Name
+
+        # Context: Parameter help
+        $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer',
+        'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'
+
+        $parameters = $_.ParameterSets.Parameters |
+        Sort-Object -Property Name -Unique |
+        Where-Object { $_.Name -notin $common }
+        $parameterNames = $parameters.Name
+
+        # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+        $help = Get-Help $commandName -ErrorAction SilentlyContinue
+
+        # Context: Help parameter help
+        ## Without the filter, WhatIf and Confirm parameters are still flagged in "finds help parameter in code" test
+        $helpParameters = $help.Parameters.Parameter |
+        Where-Object { $_.Name -notin $common } |
+        Sort-Object -Property Name -Unique
+
+        $helpParameterNames = $helpParameters.Name
+    }
+
+    # If help is not found, synopsis in auto-generated help is the syntax diagram
+    It 'should not be auto-generated' {
+        $help.Synopsis | Should -Not -BeLike '*`[`<CommonParameters`>`]*'
+    }
+
+    # Should be a description for every function
+    It "gets description for <commandName>" {
+        $help.Description | Should -Not -BeNullOrEmpty
+    }
+
+    # Should be at least one example
+    It "gets example code from <commandName>" {
+        ($help.Examples.Example | Select-Object -First 1).Code | Should -Not -BeNullOrEmpty
+    }
+
+    # Should be at least one example description
+    It "gets example help from <commandName>" {
+        ($help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not -BeNullOrEmpty
+    }
+
+    Context "Test <_.Name> parameter help for <commandName>" -Foreach $parameters {
+
+        BeforeAll {
+
+            $parameterName = $_.Name
+            $parameterHelp = $help.parameters.parameter | Where-Object Name -EQ $parameterName
+
         }
 
-        # Should be a description for every function
-        It "gets description for $commandName" {
-            $help.Description | Should Not BeNullOrEmpty
+        # Should be a description for every parameter
+        It "gets help for parameter: <_.Name> : in <commandName>" {
+            $parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
         }
 
-        # Should be at least one example
-        It "gets example code from $commandName" {
-            ($help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+        # Required value in Help should match IsMandatory property of parameter
+        It "help for <_.Name> parameter in <commandName> has correct Mandatory value" {
+            $codeMandatory = $_.IsMandatory.toString()
+            $parameterHelp.Required | Should -Be $codeMandatory
         }
 
-        # Should be at least one example description
-        It "gets example help from $commandName" {
-            ($help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+        # Parameter type in Help should match code
+        # It "help for $commandName has correct parameter type for $parameterName" {
+        #     $codeType = $_.ParameterType.Name
+        #     # To avoid calling Trim method on a null object.
+        #     $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+        #     $helpType | Should -Be $codeType
+        # }
+    }
+
+    Context "Test <_> help parameter help for <commandName>" -Foreach $helpParameterNames {
+
+        # Shouldn't find extra parameters in help.
+        It "finds help parameter in code: <_>" {
+            $_ -in $parameterNames | Should -Be $true
         }
 
-        Context "Test parameter help for $commandName" {
+    }
 
-            $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer',
-                'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'
+    Context "Help Links should be Valid for $commandName" -Foreach $links {
 
-            $parameters = $command.ParameterSets.Parameters |
-                Sort-Object -Property Name -Unique |
-                Where-Object { $_.Name -notin $common }
-            $parameterNames = $parameters.Name
-
-            ## Without the filter, WhatIf and Confirm parameters are still flagged in "finds help parameter in code" test
-            $helpParameters = $help.Parameters.Parameter |
-                Where-Object { $_.Name -notin $common } |
-                Sort-Object -Property Name -Unique
-            $helpParameterNames = $helpParameters.Name
-
-            foreach ($parameter in $parameters) {
-                $parameterName = $parameter.Name
-                $parameterHelp = $help.parameters.parameter | Where-Object Name -EQ $parameterName
-
-                # Should be a description for every parameter
-                It "gets help for parameter: $parameterName : in $commandName" {
-                    $parameterHelp.Description.Text | Should Not BeNullOrEmpty
-                }
-
-                # Required value in Help should match IsMandatory property of parameter
-                It "help for $parameterName parameter in $commandName has correct Mandatory value" {
-                    $codeMandatory = $parameter.IsMandatory.toString()
-                    $parameterHelp.Required | Should Be $codeMandatory
-                }
-
-                # Parameter type in Help should match code
-                # It "help for $commandName has correct parameter type for $parameterName" {
-                #     $codeType = $parameter.ParameterType.Name
-                #     # To avoid calling Trim method on a null object.
-                #     $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
-                #     $helpType | Should be $codeType
-                # }
+        if ($_) {
+            # Should have a valid uri if one is provided.
+            it "[$link] should have 200 Status Code for $commandName" {
+                $Results = Invoke-WebRequest -Uri $link -UseBasicParsing
+                $Results.StatusCode | Should -Be '200'
             }
-
-            foreach ($helpParm in $HelpParameterNames) {
-                # Shouldn't find extra parameters in help.
-                It "finds help parameter in code: $helpParm" {
-                    $helpParm -in $parameterNames | Should Be $true
-                }
-            }
         }
 
-        Context "Help Links should be Valid for $commandName" {
-            $link = $help.relatedLinks.navigationLink.uri
-
-            foreach ($link in $links) {
-                if ($link) {
-                    # Should have a valid uri if one is provided.
-                    it "[$link] should have 200 Status Code for $commandName" {
-                        $Results = Invoke-WebRequest -Uri $link -UseBasicParsing
-                        $Results.StatusCode | Should Be '200'
-                    }
-                }
-            }
-        }
     }
 }

--- a/Stucco/template/tests/Manifest.tests.ps1
+++ b/Stucco/template/tests/Manifest.tests.ps1
@@ -1,85 +1,93 @@
+BeforeAll {
 
-$moduleName         = $env:BHProjectName
-$manifest           = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
-$outputDir          = Join-Path -Path $ENV:BHProjectPath -ChildPath 'Output'
-$outputModDir       = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
-$outputModVerDir    = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
-$outputManifestPath = Join-Path -Path $outputModVerDir -Child "$($moduleName).psd1"
-$changelogPath      = Join-Path -Path $env:BHProjectPath -Child 'CHANGELOG.md'
+    $moduleName = $env:BHProjectName
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $ENV:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputManifestPath = Join-Path -Path $outputModVerDir -Child "$($moduleName).psd1"
+    $changelogPath = Join-Path -Path $env:BHProjectPath -Child 'CHANGELOG.md'
 
+    $script:manifest = $null
+
+}
 Describe 'Module manifest' {
-    Context 'Validation' {
 
-        $script:manifest = $null
+    Context 'Validation' {
 
         It 'has a valid manifest' {
             {
                 $script:manifest = Test-ModuleManifest -Path $outputManifestPath -Verbose:$false -ErrorAction Stop -WarningAction SilentlyContinue
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'has a valid name in the manifest' {
-            $script:manifest.Name | Should Be $env:BHProjectName
+            $script:manifest.Name | Should -Be $env:BHProjectName
         }
 
         It 'has a valid root module' {
-            $script:manifest.RootModule | Should Be "$($moduleName).psm1"
+            $script:manifest.RootModule | Should -Be "$($moduleName).psm1"
         }
 
         It 'has a valid version in the manifest' {
-            $script:manifest.Version -as [Version] | Should Not BeNullOrEmpty
+            $script:manifest.Version -as [Version] | Should -Not -BeNullOrEmpty
         }
 
         It 'has a valid description' {
-            $script:manifest.Description | Should Not BeNullOrEmpty
+            $script:manifest.Description | Should -Not -BeNullOrEmpty
         }
 
         It 'has a valid author' {
-            $script:manifest.Author | Should Not BeNullOrEmpty
+            $script:manifest.Author | Should -Not -BeNullOrEmpty
         }
 
         It 'has a valid guid' {
             {
                 [guid]::Parse($script:manifest.Guid)
-            } | Should Not throw
+            } | Should -Not -Throw
         }
 
         It 'has a valid copyright' {
-            $script:manifest.CopyRight | Should Not BeNullOrEmpty
+            $script:manifest.CopyRight | Should -Not -BeNullOrEmpty
         }
 
-        $script:changelogVersion = $null
         It 'has a valid version in the changelog' {
+
+            $script:changelogVersion = $null
+
             foreach ($line in (Get-Content $changelogPath)) {
                 if ($line -match "^##\s\[(?<Version>(\d+\.){1,3}\d+)\]") {
                     $script:changelogVersion = $matches.Version
                     break
                 }
             }
-            $script:changelogVersion               | Should Not BeNullOrEmpty
-            $script:changelogVersion -as [Version] | Should Not BeNullOrEmpty
+            $script:changelogVersion               | Should -Not -BeNullOrEmpty
+            $script:changelogVersion -as [Version] | Should -Not -BeNullOrEmpty
         }
 
         It 'changelog and manifest versions are the same' {
-            $script:changelogVersion -as [Version] | Should be ( $script:manifest.Version -as [Version] )
+            $script:changelogVersion -as [Version] | Should -Be ( $script:manifest.Version -as [Version] )
         }
 
         if (Get-Command git.exe -ErrorAction SilentlyContinue) {
-            $script:tagVersion = $null
+
             It 'is tagged with a valid version' -skip {
+
+                $script:tagVersion = $null
+
                 $thisCommit = git.exe log --decorate --oneline HEAD~1..HEAD
 
                 if ($thisCommit -match 'tag:\s*(\d+(?:\.\d+)*)') {
                     $script:tagVersion = $matches[1]
                 }
 
-                $script:tagVersion               | Should Not BeNullOrEmpty
-                $script:tagVersion -as [Version] | Should Not BeNullOrEmpty
+                $script:tagVersion               | Should -Not -BeNullOrEmpty
+                $script:tagVersion -as [Version] | Should -Not -BeNullOrEmpty
             }
 
             It 'all versions are the same' {
-                $script:changelogVersion -as [Version] | Should be ( $script:manifest.Version -as [Version] )
-                #$script:manifest.Version -as [Version] | Should be ( $script:tagVersion -as [Version] )
+                $script:changelogVersion -as [Version] | Should -Be ( $script:manifest.Version -as [Version] )
+                #$script:manifest.Version -as [Version] | Should -Be ( $script:tagVersion -as [Version] )
             }
         }
     }

--- a/Stucco/template/tests/Meta.tests.ps1
+++ b/Stucco/template/tests/Meta.tests.ps1
@@ -1,18 +1,23 @@
-Set-StrictMode -Version latest
+BeforeAll {
 
-# Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
-Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Verbose:$false -Force
+    Set-StrictMode -Version latest
 
-$projectRoot = $ENV:BHProjectPath
-if(-not $projectRoot) {
-    $projectRoot = $PSScriptRoot
+    # Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Verbose:$false -Force
+
+    $projectRoot = $ENV:BHProjectPath
+    if (-not $projectRoot) {
+        $projectRoot = $PSScriptRoot
+    }
+
+    $allTextFiles = Get-TextFilesList $projectRoot
+
 }
 
 Describe 'Text files formatting' {
 
-    $allTextFiles = Get-TextFilesList $projectRoot
-
     Context 'Files encoding' {
+
         It "Doesn't use Unicode encoding" {
             $unicodeFilesCount = 0
             $allTextFiles | Foreach-Object {
@@ -23,9 +28,11 @@ Describe 'Text files formatting' {
             }
             $unicodeFilesCount | Should -Be 0
         }
+
     }
 
     Context 'Indentations' {
+
         It 'Uses spaces for indentation, not tabs' {
             $totalTabsCount = 0
             $allTextFiles | Foreach-Object {
@@ -37,5 +44,6 @@ Describe 'Text files formatting' {
             }
             $totalTabsCount | Should -Be 0
         }
+
     }
 }


### PR DESCRIPTION
Modified the three test files to enable compatibility with Pester 5.

## Description

Help.tests.ps1
- Changed assertion syntax to use parameters.
- Wrapped initialisation in `BeforeDiscovery { }` block (including new `$params` logic which is unreleased to PSGallery).
- Removed `foreach` and changed to data-driven tests, i.e. Describe `-ForEach $commands` 
- Removed parameter help and uri foreach loops and changed to data-driven tests in Context loops.
- Fixed (?) `$links` variable initialisation typo (was `$link`) line 57
- Moved code to both `BeforeDiscovery { }` and `BeforeAll { }` as it is _used in both Discovery and Test phases_
- Renamed assertion names to use new `< >` templates

Manifest.tests.ps1
- Changed assertion syntax to use parameters.
- Wrapped initialisation in `BeforeAll { }`
- Moved some variable declaration / resets (?) into assertion blocks, e.g. `$script:changelogVersion = $null`

Meta.tests.ps1
- Wrapped initialisation in `BeforeAll { }`

## Related Issue

https://github.com/devblackops/Stucco/issues/18

## Motivation and Context

Project did not build/pass test with Pester 5 due to breaking changes.

## How Has This Been Tested?

- Created new project using Plaster and all tests passed. 
- Applied tests to existing project and all tests generated and passed.
- Not tested backward compatibility with Pester 4 etc


## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
