### PR TITLE
Update tests to Pester v5

### DIFF
--- a/Stucco/template/requirements.psd1
+++ b/Stucco/template/requirements.psd1
@@ -3,10 +3,7 @@
         Target = 'CurrentUser'
     }
     'Pester' = @{
-        Version = '4.9.0'
-        Parameters = @{
-            SkipPublisherCheck = $true
-        }
+        Version = '5.1.1'
     }
     'psake' = @{
         Version = '4.8.0'

--- a/Stucco/template/tests/Help.tests.ps1
+++ b/Stucco/template/tests/Help.tests.ps1
@@ -18,7 +18,7 @@ Describe 'Help Tests' {
     BeforeDiscovery {
         # $env:BHProjectName (Module Info from BuildHelpers)
         $params = @{
-            Module = (Get-Module $ModuleName)
+            Module = (Get-Module $env:BHProjectName)
             CommandType = [System.Management.Automation.CommandTypes[]]'Cmdlet, Function' # Not alias
         }
 

--- a/Stucco/template/tests/Meta.tests.ps1
+++ b/Stucco/template/tests/Meta.tests.ps1
@@ -1,41 +1,40 @@
-Set-StrictMode -Version latest
-
-# Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
-Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Verbose:$false -Force
-
-$projectRoot = $ENV:BHProjectPath
-if(-not $projectRoot) {
-    $projectRoot = $PSScriptRoot
-}
-
 Describe 'Text files formatting' {
+    BeforeAll {
+        Set-StrictMode -Version latest
 
-    $allTextFiles = Get-TextFilesList $projectRoot
+        # Make sure MetaFixers.psm1 is loaded
+        Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'MetaFixers.psm1') -Verbose:$false -Force
 
-    Context 'Files encoding' {
-        It "Doesn't use Unicode encoding" {
-            $unicodeFilesCount = 0
-            $allTextFiles | Foreach-Object {
-                if (Test-FileUnicode $_) {
-                    $unicodeFilesCount += 1
-                    Write-Warning "File $($_.FullName) contains 0x00 bytes. It's probably uses Unicode and need to be converted to UTF-8. Use Fixer 'Get-UnicodeFilesList `$pwd | ConvertTo-UTF8'."
-                }
+        $allTextFiles = Get-TextFilesList $env:BHProjectPath
+
+        $unicodeFilesCount = 0
+        $totalTabsCount = 0
+
+        foreach ($textFile in $allTextFiles) {
+            if (Test-FileUnicode $textFile) {
+                $unicodeFilesCount++
+                Write-Warning (
+                    "File $($textFile.FullName) contains 0x00 bytes." +
+                    " It probably uses Unicode/UTF-16 and needs to be converted to UTF-8." +
+                    " Use Fixer 'Get-UnicodeFilesList `$pwd | ConvertTo-UTF8'."
+                )
             }
-            $unicodeFilesCount | Should -Be 0
+            $fileName = $textFile.FullName
+                (Get-Content $fileName -Raw) | Select-String "`t" | Foreach-Object {
+                    Write-Warning (
+                        "There are tabs in $fileName." +
+                        " Use Fixer 'Get-TextFilesList `$pwd | ConvertTo-SpaceIndentation'."
+                    )
+                    $totalTabsCount++
+                }
         }
     }
 
-    Context 'Indentations' {
-        It 'Uses spaces for indentation, not tabs' {
-            $totalTabsCount = 0
-            $allTextFiles | Foreach-Object {
-                $fileName = $_.FullName
-                (Get-Content $_.FullName -Raw) | Select-String "`t" | Foreach-Object {
-                    Write-Warning "There are tab in $fileName. Use Fixer 'Get-TextFilesList `$pwd | ConvertTo-SpaceIndentation'."
-                    $totalTabsCount++
-                }
-            }
-            $totalTabsCount | Should -Be 0
-        }
+    It "no text file uses Unicode/UTF-16 encoding" {
+        $unicodeFilesCount | Should -Be 0
+    }
+
+    It "no text file use tabs for indentations" {
+        $totalTabsCount | Should -Be 0
     }
 }

--- a/Stucco/template/tests/MetaFixers.psm1
+++ b/Stucco/template/tests/MetaFixers.psm1
@@ -42,8 +42,12 @@ function Get-TextFilesList {
         [Parameter(Mandatory)]
         [string]$Root
     )
+
     Get-ChildItem -Path $Root -File -Recurse |
-        Where-Object { @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') -contains $_.Extension }
+        Where-Object {
+            @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') `
+                -contains $_.Extension
+        }
 }
 
 function Test-FileUnicode {
@@ -59,7 +63,6 @@ function Test-FileUnicode {
         $bytes = [System.IO.File]::ReadAllBytes($path)
         $zeroBytes = @($bytes -eq 0)
         return [bool]$zeroBytes.Length
-
     }
 }
 


### PR DESCRIPTION
Updating Help, Meta and Manifest tests in template to Pester v5.
Did some code cleanup in the same tests as well.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updating all tests in template to support Pester v5 by using the proper parameter syntax as well as proper scoping of code blocks into BeforeDiscovery/BeforeAll/etc.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/devblackops/Stucco/issues/18
Also similar PR: https://github.com/devblackops/Stucco/pull/19

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To get the template compatible with the latest Pester stable (v5)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created a test module out of this updated template.
- Created a function with params.
- Confirmed the test output from the new v5 Pester tests.
- I've created a template heavily inspired by Stucco for work and went through the process of upgrading it to Pester v5 over there.
- Just bringing the changes over here now!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
