### PR TITLE
Change FilterOutCommonParams to global

### DIFF
--- a/Stucco/template/tests/Help.tests.ps1
+++ b/Stucco/template/tests/Help.tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeDiscovery {
 
-    function script:FilterOutCommonParams {
+    function global:FilterOutCommonParams {
         param ($Params)
         $commonParams = @(
             'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
@@ -41,7 +41,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         # Get command help, parameters, and links
         $command               = $_
         $commandHelp           = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters     = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters     = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
         $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri
     }
@@ -51,9 +51,9 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         $command                = $_
         $commandName            = $_.Name
         $commandHelp            = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters      = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters      = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames  = $commandParameters.Name
-        $helpParameters         = script:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
+        $helpParameters         = global:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
         $helpParameterNames     = $helpParameters.Name
     }
 

--- a/Tests/Help.tests.ps1
+++ b/Tests/Help.tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeDiscovery {
 
-    function script:FilterOutCommonParams {
+    function global:FilterOutCommonParams {
         param ($Params)
         $commonParams = @(
             'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
@@ -41,7 +41,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         # Get command help, parameters, and links
         $command               = $_
         $commandHelp           = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters     = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters     = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
         $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri
     }
@@ -51,9 +51,9 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         $command                = $_
         $commandName            = $_.Name
         $commandHelp            = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters      = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters      = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames  = $commandParameters.Name
-        $helpParameters         = script:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
+        $helpParameters         = global:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
         $helpParameterNames     = $helpParameters.Name
     }
 


### PR DESCRIPTION
Minor tweak to `FilterOutCommonParams` to be global.

## Description
Pester isn't picking up the script level function. The global function should resolve that.

## Related Issue
#26 

## Motivation and Context
This well let Pester 5 find it.

## How Has This Been Tested?
This test is included on the repo so I'm hoping the CI on the PR will validate it.
I use it currently for https://github.com/HeyItsGilbert/RPGDice/blob/main/tests/Help.tests.ps1#L5

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
