### PR TITLE
Updates build.ps1 with ArgumentCompleter attribute on Task parameter

### DIFF
--- a/Stucco/template/build.ps1
+++ b/Stucco/template/build.ps1
@@ -7,7 +7,14 @@ param(
         $psakeFile = './psakeFile.ps1'
         switch ($Parameter) {
             'Task' {
-                Get-PSakeScriptTasks -buildFile $psakeFile | Select-Object -ExpandProperty Name
+                if ([string]::IsNullOrEmpty($WordToComplete)) {
+                    Get-PSakeScriptTasks -buildFile $psakeFile | Select-Object -ExpandProperty Name
+                }
+                else {
+                    Get-PSakeScriptTasks -buildFile $psakeFile |
+                        Where-Object { $_.Name -match $WordToComplete } |
+                        Select-Object -ExpandProperty Name
+                }
             }
             Default {
             }

--- a/Stucco/template/build.ps1
+++ b/Stucco/template/build.ps1
@@ -2,6 +2,17 @@
 param(
     # Build task(s) to execute
     [parameter(ParameterSetName = 'task', position = 0)]
+    [ArgumentCompleter( {
+        param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
+        $psakeFile = './psakeFile.ps1'
+        switch ($Parameter) {
+            'Task' {
+                Get-PSakeScriptTasks -buildFile $psakeFile | Select-Object -ExpandProperty Name
+            }
+            Default {
+            }
+        }
+    })]
     [string[]]$Task = 'default',
 
     # Bootstrap dependencies


### PR DESCRIPTION
This adds autocomplete to the Task parameter.

## Description
The ArgumentCompleter attribute works by reading the `psakefile.ps1` with `Get-PSakeScriptTasks` and providing autocomplete suggestions.

## Related Issue
Discussion #25 

## Motivation and Context
Helps Task discovery

## How Has This Been Tested?
Works on my machine, and seems simple enough

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
