### PR TITLE
align template gitignore with stucco gitignore

### DIFF
--- a/Stucco/template/_gitignore
+++ b/Stucco/template/_gitignore
@@ -1,2 +1,6 @@
 # Don't check in the Output dir
 Output/
+
+scratch/
+
+testResults.xml


### PR DESCRIPTION
## Description
additional entries in the template gitignore to prevent some manual steps on module creation

## Related Issue
(https://github.com/devblackops/Stucco/issues/29)

## Motivation and Context
Goal is to smooth out the creation of a module from a stucco template
these gitignores we have been adding manually to every project
and have noticed that they are already in the stucco module itself

## How Has This Been Tested?
tested in modules I have deployed from stucco

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
