### PR TITLE
Added support for Jenkins CI in module template

### DIFF
--- a/Stucco/plasterManifest.xml
+++ b/Stucco/plasterManifest.xml
@@ -142,15 +142,22 @@
       <choice label='Azure &amp;Pipelines'
               help='Adds an Azure Pipelines yaml file.'
               value='AzurePipelines'/>
-    <choice label='Git&amp;Hub Actions'
+      <choice label='Git&amp;Hub Actions'
               help='Adds a GitHub Actions workflow file.'
               value='GitHubActions'/>
       <choice label='&amp;GitLab CI'
               help='Adds a GitLab CI yaml file.'
               value='GitLabCI'/>
+      <choice label='&amp;Jenkins CI'
+              help='Adds a Jenkkinsfile file.'
+              value='JenkinsCI'/>
+      <choice label='&amp;MJenkins CI(MultiStage)'
+              help='Adds a Jenkinsfile with multiple stages.'
+              value='JenkinsCI-MultiStage'/>
       <choice label='&amp;None'
               help='No license specified.'
               value='None'/>
+
     </parameter>
 
 
@@ -209,6 +216,14 @@ Creating an opinionated high-quality PowerShell module with psake tasks and GitH
       source='template/cicd/.gitlab-ci.yml'
       destination='.gitlab-ci.yml'
       condition="$PLASTER_PARAM_CICD -eq 'GitLabCI'"/>
+    <templateFile
+      source='template/cicd/jenkinsfile'
+      destination='Jenkinsfile'
+      condition="$PLASTER_PARAM_CICD -eq 'JenkinsCI'"/>
+    <templateFile
+      source='template/cicd/jenkinsfile-multistage'
+      destination='Jenkinsfile'
+      condition="$PLASTER_PARAM_CICD -eq 'JenkinsCI-MultiStage'"/>
 
     <!-- Project docs -->
     <templateFile

--- a/Stucco/template/cicd/jenkinsfile
+++ b/Stucco/template/cicd/jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+
+    agent { label 'Windows' }
+
+    environment {
+    PSGALLERY_API_KEY = credentials('PSGALLERY_API_KEY')
+  }
+
+   stages {
+    stage('build') {
+       steps {
+         powershell './build.ps1 -Task Publish -Bootstrap'
+      }
+    }
+  }
+}

--- a/Stucco/template/cicd/jenkinsfile-multistage
+++ b/Stucco/template/cicd/jenkinsfile-multistage
@@ -1,0 +1,40 @@
+pipeline {
+
+    agent { label 'Windows' }
+
+    environment {
+    PSGALLERY_API_KEY = credentials('PSGALLERY_API_KEY')
+  }
+   stages {
+    stage('Init') {
+       steps {
+         powershell './build.ps1 -Task Init -Bootstrap'
+      }
+    }
+    stage('Clean') {
+       steps {
+         powershell './build.ps1 -Task Clean'
+      }
+    }
+    stage('Build') {
+       steps {
+         powershell './build.ps1 -Task Build'
+      }
+    }
+    stage('Analyze') {
+       steps {
+         powershell './build.ps1 -Task Analyze'
+      }
+    }
+    stage('Pester') {
+       steps {
+         powershell './build.ps1 -Task Pester'
+      }
+    }
+    stage('Publish') {
+       steps {
+         powershell './build.ps1 -Task Publish'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added support for Jenkins CI in module template

## Description
You can now choose (J) to add a Jenkinsfile to your module containing one Stage to build,test etc. in one single step
or you can choose (M) too add a multistage Jenkinsfile containing 6 stages for every single step of the build.

## Related Issue
none

## Motivation and Context
I wanted to use a Jenkins multibranch pipeline to build my module after it was created with Stucco

## How Has This Been Tested?
* Created a Testmodule with option (J) in Stucco, added a multibranch pipeline to Jenkins, setting a secret "PSGALLERY_API_KEY" for $env:PSGALLERY_API_KEY
* Created a Testmodule with option (M) in Stucco, added a multibranch pipeline to Jenkins, setting a secret "PSGALLERY_API_KEY" for $env:PSGALLERY_API_KEY
* Successful push to internal repository

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
