### PR TITLE
fix to help tests for powershell 74

### DIFF
--- a/Stucco/template/tests/Help.tests.ps1
+++ b/Stucco/template/tests/Help.tests.ps1
@@ -4,11 +4,7 @@ BeforeDiscovery {
 
     function global:FilterOutCommonParams {
         param ($Params)
-        $commonParams = @(
-            'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
-            'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction',
-            'WarningVariable', 'Confirm', 'Whatif'
-        )
+        $commonParams = [System.Management.Automation.PSCmdlet]::OptionalCommonParameters + [System.Management.Automation.PSCmdlet]::CommonParameters
         $params | Where-Object { $_.Name -notin $commonParams } | Sort-Object -Property Name -Unique
     }
 

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -4,11 +4,7 @@ BeforeDiscovery {
 
     function global:FilterOutCommonParams {
         param ($Params)
-        $commonParams = @(
-            'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
-            'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction',
-            'WarningVariable', 'Confirm', 'Whatif'
-        )
+        $commonParams = [System.Management.Automation.PSCmdlet]::OptionalCommonParameters + [System.Management.Automation.PSCmdlet]::CommonParameters
         $params | Where-Object { $_.Name -notin $commonParams } | Sort-Object -Property Name -Unique
     }
 


### PR DESCRIPTION
## Description
as mentioned in the issue, 
powershell 7.4 broke help.tsts.ps1

## Related Issue
related issue https://github.com/devblackops/Stucco/issues/41

## Motivation and Context
as mentioned in the issue, 
powershell 7.4 broke help.tsts.ps1
this is to rectify that issue for the stucco repo AND the template

## How Has This Been Tested?
tests on development machine using variety of powershell versions
test using devcontainer pinned with different versions including powershell 7.2 7.3 7.4
and os options of ubuntu 20.04 and 22.04
additionally on windows 11 environment

## Screenshots (if appropriate):
NA - issue contains

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
